### PR TITLE
Fix missing count in Jira search results for API v3

### DIFF
--- a/src/interfaces/issueInterfaces.ts
+++ b/src/interfaces/issueInterfaces.ts
@@ -109,10 +109,13 @@ export interface IJiraUser {
 
 export interface IJiraSearchResults {
     issues: IJiraIssue[]
-    maxResults: number
-    startAt: number
-    total: number
+    isLast: boolean
+    nextPageToken?: string
     account: IJiraIssueAccountSettings
+    // Legacy fields for backward compatibility
+    maxResults?: number
+    startAt?: number
+    total?: number
 }
 
 export interface IJiraStatus {

--- a/src/rendering/countFenceRenderer.ts
+++ b/src/rendering/countFenceRenderer.ts
@@ -11,8 +11,23 @@ function renderSearchCount(el: HTMLElement, searchResults: IJiraSearchResults, s
     if (searchView.label !== '') {
         createSpan({ cls: `ji-tag is-link ${RC.getTheme()}`, text: searchView.label || `Count`, title: searchView.query, parent: tagsRow })
     }
-    const total = searchResults.total || 0
-    createSpan({ cls: `ji-tag ${RC.getTheme()}`, text: total.toString(), title: searchView.query, parent: tagsRow })
+    
+    // Handle API v3 pagination - no total count available
+    let countText: string
+    if (searchResults.total !== undefined) {
+        // Legacy API v2 response with total count
+        countText = searchResults.total.toString()
+    } else {
+        // API v3 response - show current results and pagination status
+        const currentCount = searchResults.issues?.length || 0
+        if (searchResults.isLast) {
+            countText = currentCount.toString()
+        } else {
+            countText = `${currentCount}+`
+        }
+    }
+    
+    createSpan({ cls: `ji-tag ${RC.getTheme()}`, text: countText, title: searchView.query, parent: tagsRow })
     el.replaceChildren(RC.renderContainer([tagsRow]))
 }
 

--- a/src/rendering/searchFenceRenderer.ts
+++ b/src/rendering/searchFenceRenderer.ts
@@ -82,9 +82,34 @@ function getAccountBandStyle(account: IJiraIssueAccountSettings): string {
 
 function renderSearchFooter(rootEl: HTMLElement, searchView: SearchView, searchResults: IJiraSearchResults): HTMLElement {
     const searchFooter = createDiv({ cls: 'search-footer' })
-    const total = searchResults.total || 0
+    
+    // Debug: Log the search results structure to understand the API response
+    SettingsData.logRequestsResponses && console.log('JiraIssue:SearchResults structure:', {
+        total: searchResults.total,
+        maxResults: searchResults.maxResults,
+        startAt: searchResults.startAt,
+        issuesLength: searchResults.issues?.length,
+        isLast: searchResults.isLast,
+        nextPageToken: searchResults.nextPageToken,
+        searchResults: searchResults
+    })
+    
+    // Handle API v3 pagination - no total count available
     const alias = searchResults.account?.alias || 'Unknown'
-    const searchCount = `Total results: ${total.toString()} - ${alias}`
+    let searchCount: string
+    
+    if (searchResults.total !== undefined) {
+        // Legacy API v2 response with total count
+        searchCount = `Total results: ${searchResults.total.toString()} - ${alias}`
+    } else {
+        // API v3 response - show current results and pagination status
+        const currentCount = searchResults.issues?.length || 0
+        if (searchResults.isLast) {
+            searchCount = `Results: ${currentCount.toString()} (all results) - ${alias}`
+        } else {
+            searchCount = `Results: ${currentCount.toString()}+ (more available) - ${alias}`
+        }
+    }
 
     if(SettingsData.showJiraLink) {
         createEl('a', {


### PR DESCRIPTION
- Updated IJiraSearchResults interface to support API v3 pagination (isLast, nextPageToken)
- Modified search footer to show appropriate count based on pagination status
- Updated count renderer to handle API v3 response structure
- Added backward compatibility for legacy API v2 responses
- Fixed issue where total count was undefined due to API v3 changes